### PR TITLE
Typo fixup: Osbourne to Osborne in address street name

### DIFF
--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -25,7 +25,7 @@ en: &DEFAULT_EN
         desc: "We run weekly open nights on Wednesdays at 19:00. Please join our [Discord server](https://discord.gg/b9h36uyssD) for more info and updates."
         icon: fas fa-unlock-alt
       - title: "Location"
-        desc: "Our current space is in South Block, 60-64 Osbourne Street. The entrance is between the plant shop and the building reception. This is a shared building, and the reception is only open 9-5, but we are open all hours. When you arrive, send us a message on Discord or IRC, and someone will come down to let you in."
+        desc: "Our current space is in South Block, 60-64 Osborne Street. The entrance is between the plant shop and the building reception. This is a shared building, and the reception is only open 9-5, but we are open all hours. When you arrive, send us a message on Discord or IRC, and someone will come down to let you in."
         icon: fas fa-map-pin
       - title: "Membership"
         desc: "We are accepting membership requests. Come along to an open night and ask a board member about joining!"


### PR DESCRIPTION
Searching for `Osbourne Street` in Glasgow using the `openstreetmap.org` search interface did not return any results, and as a result of that I noticed the typo in the street name.